### PR TITLE
Adding wrapper classes for wallet_addEthereumChain method

### DIFF
--- a/lib/ethereum.dart
+++ b/lib/ethereum.dart
@@ -65,3 +65,36 @@ class RequestParams {
 
 @JS("JSON.stringify")
 external String stringify(dynamic obj);
+
+@JS()
+@anonymous
+class CurrencyParams {
+  external String get name;
+
+  external String get symbol;
+
+  external int get decimals;
+
+  external factory CurrencyParams({String name, String symbol, int decimals});
+}
+
+@JS()
+@anonymous
+class ChainParams {
+  external String get chainId;
+
+  external String get chainName;
+
+  external CurrencyParams get nativeCurrency;
+
+  external List<String> get rpcUrls;
+
+  external List<String> get blockExplorerUrls;
+
+  external factory ChainParams(
+      {String chainId,
+      String chainName,
+      CurrencyParams nativeCurrency,
+      List<String> rpcUrls,
+      List<String> blockExplorerUrls});
+}


### PR DESCRIPTION
These wrapper classes allow us to use _wallet_addEthereumChain_ method which is describe here - https://eips.ethereum.org/EIPS/eip-3085.

Here is the example how it could be used:
```

var nativeCurrency =
          CurrencyParams(name: "GO", symbol: "GO", decimals: 18);
      var params = ChainParams(
          chainId: '0x3c',
          chainName: "GoChain",
          nativeCurrency: nativeCurrency,
          rpcUrls: ['https://rpc.gochain.io/'],
          blockExplorerUrls: ['https://explorer.gochain.io/']);
      promiseToFuture(ethereum.request(RequestParams(
              method: 'wallet_addEthereumChain', params: [params])))
          .onError((error, stackTrace) => print("Method is not supported"));
```