### PR TITLE
add watchAsset params and options for wallet_watchAsset method

### DIFF
--- a/lib/ethereum.dart
+++ b/lib/ethereum.dart
@@ -82,14 +82,18 @@ class WatchAssetParameters {
 class WatchAssetOptions {
   external String get address;
 
-  external String? get symbol;
+  external String get symbol;
 
-  external int? get decimals;
+  external int get decimals;
 
   external String? get image;
 
-  external factory WatchAssetOptions(
-      {required String address, String? symbol, int? decimals, String? image});
+  external factory WatchAssetOptions({
+    required String address,
+    required String symbol,
+    required int decimals,
+    String? image,
+  });
 }
 
 @JS()

--- a/lib/ethereum.dart
+++ b/lib/ethereum.dart
@@ -68,6 +68,32 @@ external String stringify(dynamic obj);
 
 @JS()
 @anonymous
+class WatchAssetParameters {
+  external String get type;
+
+  external WatchAssetOptions get options;
+
+  external factory WatchAssetParameters(
+      {required String type, required WatchAssetOptions options});
+}
+
+@JS()
+@anonymous
+class WatchAssetOptions {
+  external String get address;
+
+  external String? get symbol;
+
+  external int? get decimals;
+
+  external String? get image;
+
+  external factory WatchAssetOptions(
+      {required String address, String? symbol, int? decimals, String? image});
+}
+
+@JS()
+@anonymous
 class CurrencyParams {
   external String get name;
 

--- a/lib/ethereum.dart
+++ b/lib/ethereum.dart
@@ -57,10 +57,10 @@ class Ethereum {
 class RequestParams {
   external String get method;
 
-  external List<dynamic> get params;
+  external dynamic get params;
 
   // Must have an unnamed factory constructor with named arguments.
-  external factory RequestParams({String? method, List<dynamic>? params});
+  external factory RequestParams({String? method, dynamic params});
 }
 
 @JS("JSON.stringify")


### PR DESCRIPTION
These wrapper class will allow us to use wallet_watchAsset method on Ethereum object, As specified by [EIP-747](https://eips.ethereum.org/EIPS/eip-747).

params argument of RequestParams also needs to be `dynamic` not `List<dynamic>?` as wallet_watchAsset takes one WatchAssetParameters object as a parameter on request method, otherwise will raise an error `Asset of type "undefined" not supported.`.

Code example:
```
final watchAssetParam = WatchAssetParameters(
              type: 'ERC20',
              options: WatchAssetOptions(
                address: 0xe9e7cea3dedca5984780bafc599bd69add087d56, // Required
                symbol: 'foo', // Optional
                decimals: 18, // Optional
                image: 'https://foo.io/token-image.svg', //Optional
              ),
            );

promiseToFuture(
  ethereum.request(
    RequestParams(
      method: 'wallet_watchAsset',
      params: watchAssetParam,
    ),
  ),
);
```
This will request the Ethereum provider to track the token and return true if the token was successfully added. 