### PR TITLE
add waitForTransaction and its class wrapper

### DIFF
--- a/lib/ethers.dart
+++ b/lib/ethers.dart
@@ -5,8 +5,83 @@ import 'package:js/js.dart';
 
 import 'ethereum.dart';
 
+@JS("providers")
+class Provider {
+  @JS("waitForTransaction")
+  external Future<TxReceipt> waitForTransaction(
+    String hash, [
+    int confirms = 1,
+  ]);
+}
+
+@JS()
+@anonymous
+class TxReceipt {
+  external String? get to;
+  external String get from;
+  external String? get contractAddress;
+  external int get transactionIndex;
+  external String? get root;
+  external BigNumber get gasUsed;
+  external String get logsBloom;
+  external String get blockHash;
+  external String get transactionHash;
+  external List<Log> get logs;
+  external int get blockNumber;
+  external int get confirmations;
+  external BigNumber get cumulativeGasUsed;
+  external bool get byzantium;
+  external int get status;
+
+  external factory TxReceipt({
+    String? to,
+    String from,
+    String? contractAddress,
+    int transactionIndex,
+    String? root,
+    BigNumber gasUsed,
+    String logsBloom,
+    String blockHash,
+    String transactionHash,
+    List<Log> logs,
+    int blockNumber,
+    int confirmations,
+    BigNumber cumulativeGasUsed,
+    bool byzantium,
+    int status,
+  });
+}
+
+@JS()
+@anonymous
+class Log {
+  external int get blockNumber;
+  external String get blockHash;
+  external bool get removed;
+  external int get transactionLogIndex;
+  external String get address;
+  external String get data;
+  external List<String> get topics;
+  external String get transactionHash;
+  external String get transactionIndex;
+  external String get logIndex;
+
+  external factory Log({
+    int blockNumber,
+    String blockHash,
+    bool removed,
+    int transactionLogIndex,
+    String address,
+    String data,
+    List<String> topics,
+    String transactionHash,
+    String transactionIndex,
+    String logIndex,
+  });
+}
+
 @JS("providers.Web3Provider")
-class Web3Provider {
+class Web3Provider extends Provider {
   external Web3Provider(Ethereum eth);
 
   @JS("getSigner")
@@ -20,7 +95,7 @@ class Web3Provider {
 }
 
 @JS("providers.JsonRpcProvider")
-class JsonRpcProvider {
+class JsonRpcProvider extends Provider {
   external JsonRpcProvider(String rpcUrl);
 
   @JS("getBalance")


### PR DESCRIPTION
Add waitForTransaction method for Provider, [TxReceipt](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionReceipt) and [Log](https://docs.ethers.io/v5/api/providers/types/#providers-Log) object, also inherit provider to Web3Provider and JsonRpcProvider

This should be an easier method to approach #21

Code example:
```
final web3 = Web3Provider(ethereum!);
final txReceipt = await promiseToFuture<TxReceipt>(
  web3.waitForTransaction('foo'),
);

print(txReceipt.status == 1); //true if transaction is successful, false otherwise.

```

